### PR TITLE
adding s3 bucket as backend for remote state

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-state-eks-cert-manager"
+    key    = "global/s3/terraform.tfstate"
+    region = var.region
+  }
+}
+
 provider "aws" {
   region = var.region
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   backend "s3" {
     bucket = "terraform-state-eks-cert-manager"
     key    = "global/s3/terraform.tfstate"
-    region = var.region
+    region = "us-east-2"
   }
 }
 


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

This will use a S3 bucket as backed so that we can store the terraform state remotely. Please let's merge this too only after we get the tests running so that local development is easier.

/assign @jakexks 
/hold